### PR TITLE
Add -O option to wget for twig-lint.phar

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -10,7 +10,7 @@ services:
     build:
       - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
       - 'export PATH="/var/www/.composer/vendor/bin"'
-      - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www"
+      - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
     xdebug: true
     config:
       php: .lando/.php.ini


### PR DESCRIPTION
Whenever I did a `lando rebuild`, twig-lint.phar, twig-lint.phar.1 and so on was being written. -O option prevents that.