### PR TITLE
Enable Solr Admin UI - only inside commented template in the .lando.yml file on the 9.0.x branch

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -21,7 +21,9 @@ services:
 #  memcache:
 #    type: memcached
 #  solr:
-#    type: solr:8.4
+#    type: solr:8.6
+#    portforward: true
+#    core: drupal-solr
 #    config:
 #      dir: docroot/modules/contrib/search_api_solr/solr-conf/7.x
 tooling:


### PR DESCRIPTION
## Description
Enable Solr Admin UI #32

Adding this line for Solr service inside **.lando.yml** file
`portforward: true`

## Related Issue
[This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here: https://github.com/Vardot/platformsh-varbase/issues/32

## Motivation and Context
This feature will allow for enabling the Solr Admin UI
After we've implemented and tested this on [Varbase Platformsh](https://github.com/Vardot/platformsh-varbase/pull/33)

## How Has This Been Tested?
This feature will allow for enabling the Solr Admin UI in development environments

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
