### PR TITLE
Add php-yaml to Lando app containers

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -11,6 +11,10 @@ services:
       - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
       - 'export PATH="/var/www/.composer/vendor/bin"'
       - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
+    build_as_root:
+      - apt update -y
+      - apt -y install libyaml-dev
+      - pecl install yaml
     xdebug: true
     config:
       php: .lando/.php.ini

--- a/.lando/.php.ini
+++ b/.lando/.php.ini
@@ -1,4 +1,6 @@
 [PHP]
+extension=yaml.so
+max_execution_time=180
 
 ; Xdebug
 xdebug.max_nesting_level = 256


### PR DESCRIPTION
When installing varbase in lando, it gives two warnings: Missing YAML php extension and low max_execution_time.

This PR updates the lando container to install php-yaml extension and configure max_execution_time, allowing for a clean install process.