### PR TITLE
Vardot Support Module and other Developer Experience Improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+#
+# This is an example .env file.
+#
+# If this site requires drupal/vardot_support and the site is hosted on a supported platform, the ENV vars will be set
+# automatically.
+#
+# For all other hosts, write the credentials to the file `.env` and the site will use them for the database connection.
+#
+# An example:
+DRUSH_OPTIONS_URI=
+MYSQL_DATABASE=
+MYSQL_HOSTNAME=
+MYSQL_PASSWORD=
+MYSQL_PORT=
+MYSQL_USER=

--- a/.lando.yml
+++ b/.lando.yml
@@ -34,7 +34,7 @@ services:
 
 # Node Service
 # NOTE: If you are just using Node for scripting, you don't need a separate node container.
-# Varbase includes `mouf/nodejs-installer` which puts `node` and `npm` in your `bin` dir.
+# You can `composer require mouf/nodejs-installer` which puts `node` and `npm` in your `bin` dir.
 # See https://packagist.org/packages/mouf/nodejs-installer for more infomation like how to set a specific version.
 # If you are using yarn or other node tools, require them in composer and look for their bin scripts in ./docroot/libraries.
 #

--- a/.lando.yml
+++ b/.lando.yml
@@ -20,6 +20,12 @@ services:
       - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
       - 'export PATH="/var/www/.composer/vendor/bin"'
       - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
+
+    build_as_root:
+      - apt update -y
+      - apt -y install libyaml-dev
+      - pecl install yaml
+
     xdebug: true
     config:
       php: .lando/.php.ini

--- a/.lando.yml
+++ b/.lando.yml
@@ -16,10 +16,12 @@ config:
 services:
   appserver:
     build:
-      - "composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true"
-      - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
-      - 'export PATH="/var/www/.composer/vendor/bin"'
-      - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
+      - composer install --prefer-source
+# If you want these tools in your lando, uncomment.
+#      - "composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true"
+#      - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
+#      - 'export PATH="/var/www/.composer/vendor/bin"'
+#      - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
 
     build_as_root:
       - apt update -y

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,36 +1,42 @@
+# Welcome to *your* lando file.
+# If you are using varbase-project to start a website, this file is now yours to control.
+# Edit the name and other configs to match your project.
+# Feel free to customize this file to your needs.
+
+# See https://docs.lando.dev/core/v3/recipes.html
 name: varbase
 recipe: drupal9
 config:
   webroot: docroot
   php: '8.1'
+  # @TODO: Should we remove this? Site-local drush is the recommended and supported method.
   drush: ^10
+
+# See https://docs.lando.dev/core/v3/services.html
 services:
   appserver:
-    scanner: false
     build:
       - "composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true"
       - "composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer mglaman/drupal-check"
       - 'export PATH="/var/www/.composer/vendor/bin"'
       - "wget https://asm89.github.io/d/twig-lint.phar -P /var/www -O twig-lint.phar"
-    build_as_root:
-      - apt update -y
-      - apt -y install libyaml-dev
-      - pecl install yaml
     xdebug: true
     config:
       php: .lando/.php.ini
-  node:
-    type: node
-    build:
-      - "yarn install -y"
-#  memcache:
-#    type: memcached
-#  solr:
-#    type: solr:8.6
-#    portforward: true
-#    core: drupal-solr
-#    config:
-#      dir: docroot/modules/contrib/search_api_solr/solr-conf/7.x
+
+# Node Service
+# NOTE: If you are just using Node for scripting, you don't need a separate node container.
+# Varbase includes `mouf/nodejs-installer` which puts `node` and `npm` in your `bin` dir.
+# See https://packagist.org/packages/mouf/nodejs-installer for more infomation like how to set a specific version.
+# If you are using yarn or other node tools, simply require them in composer and use `bin/yarn` or similar.
+# If you really need a Node Server, you can add it here.
+#
+#  node:
+#    type: node
+#    build:
+#      - "yarn install -y"
+
+# See https://docs.lando.dev/core/v3/tooling.html
 tooling:
   phpcs:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -36,10 +36,12 @@ services:
 # NOTE: If you are just using Node for scripting, you don't need a separate node container.
 # Varbase includes `mouf/nodejs-installer` which puts `node` and `npm` in your `bin` dir.
 # See https://packagist.org/packages/mouf/nodejs-installer for more infomation like how to set a specific version.
-# If you are using yarn or other node tools, simply require them in composer and use `bin/yarn` or similar.
+# If you are using yarn or other node tools, require them in composer and look for their bin scripts in ./docroot/libraries.
+#
+# See https://asset-packagist.org/
 #
 # This also gives the ability to use NodeJS commands in composer scripts. use this to create specific front-end build commands for your project.
-# See `composer yarn:install` command for an example.
+# See `composer npm:install` command for an example.
 #
 # If you really need a Node Server, you can add it here.
 #

--- a/.lando.yml
+++ b/.lando.yml
@@ -35,6 +35,10 @@ services:
 # Varbase includes `mouf/nodejs-installer` which puts `node` and `npm` in your `bin` dir.
 # See https://packagist.org/packages/mouf/nodejs-installer for more infomation like how to set a specific version.
 # If you are using yarn or other node tools, simply require them in composer and use `bin/yarn` or similar.
+#
+# This also gives the ability to use NodeJS commands in composer scripts. use this to create specific front-end build commands for your project.
+# See `composer yarn:install` command for an example.
+#
 # If you really need a Node Server, you can add it here.
 #
 #  node:

--- a/.lando.yml
+++ b/.lando.yml
@@ -11,6 +11,7 @@ config:
   php: '8.1'
   # @TODO: Should we remove this? Site-local drush is the recommended and supported method.
   drush: ^10
+  scanner: false
 
 # See https://docs.lando.dev/core/v3/services.html
 services:

--- a/.platform.app.yml
+++ b/.platform.app.yml
@@ -1,0 +1,32 @@
+#
+# Vardot Support
+# Suggested Platform.sh config.
+# 
+
+name: codename
+type: 'php:8.1'
+
+# Set build.flavor to "none" so we can run our own composer command.
+build:
+    flavor: none
+
+# Set hooks to the standardized composer commands.
+# See composer.json:scripts for command definitions. 
+hooks:
+    build: |
+        set -e
+        composer deploy:build
+    deploy: |
+        set -e
+        composer deploy:update
+
+# Set cron runs to once per minute.
+crons:
+    drupal:
+        spec: '* * * * *'
+        cmd: drush core-cron
+        
+# Set common PHP configuration
+variables:
+    php:
+        memory_limit: 512M

--- a/.platform/routes.yml
+++ b/.platform/routes.yml
@@ -1,0 +1,17 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+  type: upstream
+  upstream: "drupal:http"
+  cache:
+    enabled: true
+
+    # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
+    cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev",
     "vardot/varbase-updater": "2.x-dev",
-    "drupal/vardot_support": "^1.1@dev"
+    "drupal/vardot_support": "1.1.x-dev@dev"
   },
   "require-dev": {
     "drupal/core-dev": "~9.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "drupal/core-composer-scaffold": "^9",
     "drupal/core-project-message": "^9",
     "webflo/drupal-finder": "~1.0",
-    "vardot/varbase": "9.0.x-dev",
+    "vardot/varbase": "9.0.x-dev@dev",
     "vardot/varbase-updater": "2.x-dev",
     "drupal/vardot_support": "1.1.x-dev@dev"
   },
@@ -60,12 +60,10 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles",
-      "Varbase\\composer\\ScriptHandler::removeGitDirectories"
+      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-update-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles",
-      "Varbase\\composer\\ScriptHandler::removeGitDirectories"
+      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-drupal-scaffold-cmd": ["Varbase\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
   },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "drupal/core-project-message": "^9",
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev",
-    "vardot/varbase-updater": "2.x-dev"
+    "vardot/varbase-updater": "2.x-dev",
+    "drupal/vardot_support": "^1.1@dev"
   },
   "require-dev": {
     "drupal/core-dev": "~9.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev@dev",
     "vardot/varbase-updater": "2.x-dev",
-    "drupal/vardot_support": "1.1.x-dev@dev",
+    "drupal/vardot_support": "^1.1",
     "vlucas/phpdotenv": "^5.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,9 @@
       "drupal/core-composer-scaffold": true,
       "drupal/core-project-message": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "vardot/varbase-updater": true
+      "vardot/varbase-updater": true,
+      "php-http/discovery": true,
+      "pyrech/composer-changelogs": true
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
     "drupal/core-project-message": "^9",
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev",
-    "vardot/varbase-updater": "2.x-dev"
+    "vardot/varbase-updater": "2.x-dev",
+    "mouf/nodejs-installer": "*",
+    "npm-asset/yarn": "^2.4"
   },
   "require-dev": {
     "drupal/core-dev": "~9.0",
@@ -52,7 +54,8 @@
       "drupal/core-composer-scaffold": true,
       "drupal/core-project-message": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "vardot/varbase-updater": true
+      "vardot/varbase-updater": true,
+      "mouf/nodejs-installer": true
     }
   },
   "scripts": {
@@ -64,7 +67,12 @@
       "Varbase\\composer\\ScriptHandler::createRequiredFiles",
       "Varbase\\composer\\ScriptHandler::removeGitDirectories"
     ],
-    "post-drupal-scaffold-cmd": ["Varbase\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
+    "post-drupal-scaffold-cmd": ["Varbase\\composer\\ScriptHandler::postDrupalScaffoldProcedure"],
+    "yarn:install": [
+      "# This is an example of a composer script wrapper for NodeJS Tools. ",
+      "# The path is already set to your composer bin dir, so calling 'yarn' will call the exact version of yarn in the project",
+      "yarn install -y"
+    ]
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -58,14 +58,19 @@
       "pyrech/composer-changelogs": true
     }
   },
+  "autoload": {
+    "psr-4": {
+      "VarbaseProject\\composer\\": "scripts/composer"
+    }
+  },
   "scripts": {
     "post-install-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
+      "VarbaseProject\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-update-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
+      "VarbaseProject\\composer\\ScriptHandler::createRequiredFiles"
     ],
-    "post-drupal-scaffold-cmd": ["Varbase\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
+    "post-drupal-scaffold-cmd": ["VarbaseProject\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev@dev",
     "vardot/varbase-updater": "2.x-dev",
-    "drupal/vardot_support": "1.1.x-dev@dev"
+    "drupal/vardot_support": "1.1.x-dev@dev",
+    "vlucas/phpdotenv": "^5.5"
   },
   "require-dev": {
     "drupal/core-dev": "~9.0",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
     }
   },
   "autoload": {
+    "files": [
+      "load.environment.php"
+    ],
     "psr-4": {
       "VarbaseProject\\composer\\": "scripts/composer"
     }

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,14 @@
     "post-update-cmd": [
       "VarbaseProject\\composer\\ScriptHandler::createRequiredFiles"
     ],
-    "post-drupal-scaffold-cmd": ["VarbaseProject\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
+    "post-drupal-scaffold-cmd": ["VarbaseProject\\composer\\ScriptHandler::postDrupalScaffoldProcedure"],
+    "varbase:install": [
+      "drush site:install varbase varbase_multilingual_configuration.enable_multilingual=true varbase_extra_components.vmi=true varbase_extra_components.varbase_heroslider_media=true varbase_extra_components.varbase_carousels=true varbase_extra_components.varbase_search=true varbase_extra_components.varbase_blog=true varbase_extra_components.varbase_auth=true install_configure_form.enable_update_status_emails=NULL",
+      "@varbase:login"
+    ],
+    "varbase:login": [
+      "drush uli"
+    ]
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/load.environment.php
+++ b/load.environment.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is included very early. See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files
+ */
+
+use Dotenv\Dotenv;
+
+/**
+ * Load any .env file. See /.env.example.
+ *
+ * Drupal has no official method for loading environment variables and uses
+ * getenv() in some places.
+ */
+$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+$dotenv->safeLoad();

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace VarbaseProject\composer;
+
+use Composer\Semver\Comparator;
+use Symfony\Component\Filesystem\Filesystem;
+use Composer\EventDispatcher\Event;
+use DrupalFinder\DrupalFinder;
+
+/**
+ * Varbase Composer Script Handler.
+ */
+class ScriptHandler {
+
+  /**
+   * Get the Drupal root directory.
+   *
+   * @param string $project_root
+   *   Project root.
+   *
+   * @return string
+   *   Drupal root path.
+   */
+  protected static function getDrupalRoot($project_root) {
+    $fs = new Filesystem();
+    $drupalFinder = new DrupalFinder();
+    $drupalFinder->locateRoot(getcwd());
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+    if (!$fs->exists($drupalRoot . '/core')) {
+      return $project_root . '/docroot';
+    }
+    else {
+      return $drupalRoot;
+    }
+  }
+
+  /**
+   * Create required files.
+   *
+   * @param \Composer\EventDispatcher\Event $event
+   *   Event of create required files.
+   */
+  public static function createRequiredFiles(Event $event) {
+
+    $fs = new Filesystem();
+    $drupal_root = static::getDrupalRoot(getcwd());
+
+    $dirs = [
+      'modules',
+      'profiles',
+      'themes',
+      'libraries',
+    ];
+
+    // Required for unit testing.
+    foreach ($dirs as $dir) {
+      if (!$fs->exists($drupal_root . '/' . $dir)) {
+        $fs->mkdir($drupal_root . '/' . $dir);
+        $fs->touch($drupal_root . '/' . $dir . '/.gitkeep');
+      }
+    }
+    // Prepare the settings file for installation.
+    if (!$fs->exists($drupal_root . '/sites/default/settings.php') and $fs->exists($drupal_root . '/modules/contrib/vardot_support/settings/settings.php')) {
+      $fs->copy($drupal_root . '/modules/contrib/vardot_support/settings/settings.php', $drupal_root . '/sites/default/settings.php');
+      $fs->chmod($drupal_root . '/sites/default/settings.php', 0666);
+      $event->getIO()
+        ->write("Copied Vardot Support settings.php to sites/default/settings.php file with chmod 0666");
+    }
+    // Prepare the services file for installation.
+    if (!$fs->exists($drupal_root . '/sites/default/services.yml') and $fs->exists($drupal_root . '/sites/default/default.services.yml')) {
+      $fs->copy($drupal_root . '/sites/default/default.services.yml', $drupal_root . '/sites/default/services.yml');
+      $fs->chmod($drupal_root . '/sites/default/services.yml', 0666);
+      $event->getIO()
+        ->write("Create a sites/default/services.yml file with chmod 0666");
+    }
+    // Create the files directory with chmod 0777.
+    if (!$fs->exists($drupal_root . '/sites/default/files')) {
+      $oldmask = umask(0);
+      $fs->mkdir($drupal_root . '/sites/default/files', 0777);
+      umask($oldmask);
+      $event->getIO()
+        ->write("Create a sites/default/files directory with chmod 0777");
+    }
+  }
+
+  /**
+   * Checks if the installed version of Composer is compatible.
+   *
+   * Composer 1.0.0 and higher consider a `composer install` without having a
+   * lock file present as equal to `composer update`. We do not ship with a lock
+   * file to avoid merge conflicts downstream, meaning that if a project is
+   * installed with an older version of Composer the scaffolding of Drupal will
+   * not be triggered. We check this here instead of in drupal-scaffold to be
+   * able to give immediate feedback to the end user, rather than failing the
+   * installation after going through the lengthy process of compiling and
+   * downloading the Composer dependencies.
+   *
+   * @see https://github.com/composer/composer/pull/5035
+   */
+  public static function checkComposerVersion(Event $event) {
+    $composer = $event->getComposer();
+    $io = $event->getIO();
+    $version = $composer::VERSION;
+    // The dev-channel of composer uses the git revision as version number,
+    // try to the branch alias instead.
+    if (preg_match('/^[0-9a-f]{40}$/i', $version)) {
+      $version = $composer::BRANCH_ALIAS_VERSION;
+    }
+    // If Composer is installed through git we have no easy way to determine if
+    // it is new enough, just display a warning.
+    if ($version === '@package_version@' || $version === '@package_branch_alias_version@') {
+      $io->writeError('<warning>You are running a development version of Composer. If you experience problems, please update Composer to the latest stable version.</warning>');
+    }
+    elseif (Comparator::lessThan($version, '1.0.0')) {
+      $io->writeError('<error>Drupal-project requires Composer version 1.0.0 or higher. Please update your Composer before continuing</error>.');
+      exit(1);
+    }
+  }
+
+  /**
+   * Post Drupal Scaffold Procedure.
+   *
+   * @param \Composer\EventDispatcher\Event $event
+   *   The script event.
+   */
+  public static function postDrupalScaffoldProcedure(Event $event) {
+
+    $fs = new Filesystem();
+    $drupal_root = static::getDrupalRoot(getcwd());
+
+    if ($fs->exists($drupal_root . '/profiles/varbase/src/assets/robots-staging.txt')) {
+      // Create staging robots file.
+      copy($drupal_root . '/profiles/varbase/src/assets/robots-staging.txt', $drupal_root . '/robots-staging.txt');
+    }
+
+    if ($fs->exists($drupal_root . '/.htaccess')
+      && $fs->exists($drupal_root . '/profiles/varbase/src/assets/htaccess_extra')) {
+
+      // Alter .htaccess file.
+      $htaccess_path = $drupal_root . '/.htaccess';
+      $htaccess_lines = file($htaccess_path);
+      $lines = [];
+      foreach ($htaccess_lines as $line) {
+        $lines[] = $line;
+        if (strpos($line, "RewriteEngine on") !== FALSE) {
+          $lines = array_merge($lines, file($drupal_root . '/profiles/varbase/src/assets/htaccess_extra'));
+        }
+      }
+      file_put_contents($htaccess_path, $lines);
+    }
+
+    if ($fs->exists($drupal_root . '/profiles/varbase/src/assets/development.services.yml')) {
+      // Alter development.services.yml to have Varbase's Local development
+      // services.
+      copy($drupal_root . '/profiles/varbase/src/assets/development.services.yml', $drupal_root . '/sites/development.services.yml');
+    }
+  }
+
+  /**
+   * Find and return the path to .git repository in root folder.
+   *
+   * @param string $root
+   *   The Drupal root directory.
+   */
+  private static function removeWindowsGitDirectories($root) {
+    foreach (scandir($root) as $dirOrFile) {
+      if ('.' === $dirOrFile || '..' === $dirOrFile) {
+        continue;
+      }
+
+      if ('.git' === $dirOrFile) {
+        self::rmdirWindows($root . '/.git');
+      }
+      elseif (!is_file($root . '/' . $dirOrFile)) {
+        self::removeWindowsGitDirectories($root . '/' . $dirOrFile);
+      }
+    }
+  }
+
+  /**
+   * Remove a directory on Windows.
+   *
+   * @param string $dirname
+   *   The directory name.
+   */
+  private static function rmdirWindows($dirname) {
+    if (is_file($dirname)) {
+      unlink($dirname);
+      return;
+    }
+
+    $dir = dir($dirname);
+    while (FALSE !== $entry = $dir->read()) {
+      if ($entry === '.' || $entry === '..') {
+        continue;
+      }
+      self::rmdirWindows("$dirname/$entry");
+    }
+
+    $dir->close();
+    rmdir($dirname);
+  }
+
+}

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -12,6 +12,8 @@ use DrupalFinder\DrupalFinder;
  */
 class ScriptHandler {
 
+    static $vardotSupportSettingsFilePath = 'modules/contrib/vardot_support/settings/settings.default.php';
+
   /**
    * Get the Drupal root directory.
    *
@@ -60,8 +62,8 @@ class ScriptHandler {
       }
     }
     // Prepare the settings file for installation.
-    if (!$fs->exists($drupal_root . '/sites/default/settings.php') and $fs->exists($drupal_root . '/modules/contrib/vardot_support/settings/settings.php')) {
-      $fs->copy($drupal_root . '/modules/contrib/vardot_support/settings/settings.php', $drupal_root . '/sites/default/settings.php');
+    if (!$fs->exists($drupal_root . '/sites/default/settings.php') and $fs->exists($drupal_root . '/modules/contrib/vardot_support/settings/settings.default.php')) {
+      $fs->copy($drupal_root . '/modules/contrib/vardot_support/settings/settings.default.php', $drupal_root . '/sites/default/settings.php');
       $fs->chmod($drupal_root . '/sites/default/settings.php', 0666);
       $event->getIO()
         ->write("Copied Vardot Support settings.php to sites/default/settings.php file with chmod 0666");


### PR DESCRIPTION
This PR adds the Vardot Support module to Varbase.

See https://drupal.org/project/vardot_support.

As I was working on this, there were a few other things I noticed could be done.

This PR is a work in progress as I get vardot_support finalized.

# Tasks
- [x] Remove call to `RemoveGitDirectories`.
- [x] Require `drupal/vardot_support`.
- [x] Copied `ScriptHandler.php` from varbase and modified to copy settings.php from vardot_support module.
- [x] Prepare settings.php from drupal/vardot_support settings/settings.default.php file. 
- [ ] Site Audit features
- [ ] Vardot Support features


## Settings.php enhancements.

Right now, settings.php is created initially ScriptHandler in `vardot/varbase`. 

Typically, ScriptHandler is copied into projects to give the project finely tuned control over their project.  See https://github.com/drupal-composer/drupal-project/blob/10.x/scripts/composer/ScriptHandler.php#LL19C26-L19C45

I think we should move ScriptHandler.php from varbase to vardot_project to mirror the best practice set by `drupal-composer/drupal-project`
