### PR TITLE
composer require drupal/vardot_support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "drupal/core-project-message": "^9 || ^10",
     "webflo/drupal-finder": "~1.0",
     "vardot/varbase": "9.0.x-dev",
-    "vardot/varbase-updater": "2.x-dev"
+    "vardot/varbase-updater": "2.x-dev",
+    "drupal/vardot_support": "^1.1@beta"
   },
   "require-dev": {
     "drupal/core-dev": "~9.0 || ~10.0",
@@ -52,7 +53,9 @@
       "drupal/core-composer-scaffold": true,
       "drupal/core-project-message": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "vardot/varbase-updater": true
+      "vardot/varbase-updater": true,
+      "pyrech/composer-changelogs": true,
+      "php-http/discovery": true
     }
   },
   "scripts": {


### PR DESCRIPTION
This is a draft PR that could remain open to test compatibility with the Vardot Support Module (https://www.drupal.org/project/vardot_support).

It only has one change:

[composer require drupal/vardot_support](https://github.com/Vardot/varbase-project/commit/e3f9a3f34c4a1caa52a19685771845417d700368)

When I ran it locally, it properly installed the latest beta.

Let me know what you think. I think it's a good way to make sure the support module can always be added.